### PR TITLE
fixing pluto directory issues

### DIFF
--- a/Boaz.py
+++ b/Boaz.py
@@ -812,7 +812,7 @@ def run_obfuscation(loader_path):
         else:
             print(f"Expected patch file not found: {patch_file}. Obfuscation may have failed.")
     except subprocess.CalledProcessError as e:
-        print(f"[*] Some Obfuscation steps have not completed with {e}. But do not worry, proceeding with the next steps.")
+        print(f"Warning: Obfuscation step has some errors {e}. But do not worry, proceeding with the next steps.")
         # Since obf_file is now defined outside of the try block, it can be safely used here
         if os.path.exists(patch_file):
             os.rename(patch_file, obf_file)
@@ -866,13 +866,13 @@ def compile_output(loader_path, output_name, compiler, sleep_flag, anti_emulatio
     elif compiler == "pluto":
         # Default LLVM passes for Pluto, if any, can be specified here
         mllvm_passes = ','.join(mllvm_options) if mllvm_options else ""
-        # compile_command = ['./llvm_obfuscator_pluto/bin/clang++', '-O3', '-flto', '-fuse-ld=lld',
+        # compile_command = ['./Pluto/llvm_obfuscator_pluto/bin/clang++', '-O3', '-flto', '-fuse-ld=lld',
         #                    '-mllvm', f'-passes={mllvm_passes}',
         #                    '-Xlinker', '-mllvm', '-Xlinker', '-passes=hlw,idc',
         #                    '-target', 'x86_64-w64-mingw32', loader_path,
         #                    '-o', output_name, '-v', '-L/usr/lib/gcc/x86_64-w64-mingw32/12-win32',
         #                    '-L./clang_test_include', '-I./c++/', '-I./c++/mingw32/']
-        compile_command = ['./llvm_obfuscator_pluto/bin/clang++', '-I.', '-I./converter', '-I./evader', '-O1', '-flto', '-fuse-ld=lld',
+        compile_command = ['./Pluto/llvm_obfuscator_pluto/bin/clang++', '-I.', '-I./converter', '-I./evader', '-O1', '-flto', '-fuse-ld=lld',
                         '-mllvm', f'-passes={mllvm_passes}',
                         '-Xlinker', '-mllvm', '-Xlinker', '-passes=hlw,idc',
                         '-target', 'x86_64-w64-mingw32', '-I.', '-I./converter', '-I./evader', loader_path]
@@ -1054,7 +1054,7 @@ def compile_with_syswhisper(loader_path, output_name, syswhisper_option, sleep_f
         subprocess.run(compile_command, check=True)
     elif compiler == "pluto":
         # Pluto-specific compilation command
-        compile_command = ["./llvm_obfuscator_pluto/bin/clang++", '-I.', '-I./converter', '-I./evader', "-fms-extensions", "-D", "nullptr=NULL", "-O1", "-flto", "-fuse-ld=lld",
+        compile_command = ["./Pluto/llvm_obfuscator_pluto/bin/clang++", '-I.', '-I./converter', '-I./evader', "-fms-extensions", "-D", "nullptr=NULL", "-O1", "-flto", "-fuse-ld=lld",
                            "-mllvm", "-passes=mba,sub,idc,bcf,fla,gle", "-Xlinker", "-mllvm", "-Xlinker", "-passes=hlw,idc",
                            "-target", "x86_64-w64-mingw32", loader_path, "./classic_stubs/syscalls.c", "./classic_stubs/syscallsstubs.std.x64.s", "-o", output_name, "-v",
                            f"-L{mingw_dir}", "-L./clang_test_include", "-I./c++/", "-I./c++/mingw32/"] + additional_sources

--- a/requirements.sh
+++ b/requirements.sh
@@ -39,6 +39,7 @@ sudo apt install -y wine
 sudo apt install -y mingw-w64
 sudo apt install -y mingw-w64-tools
 sudo apt install -y x86_64-w64-mingw32-g++
+sudo apt install -y nasm
 sudo dpkg --add-architecture i386
 apt-get install wine32:i386
 
@@ -176,42 +177,24 @@ else
 fi
 
 
-#!/bin/bash
 if [ ! -d "llvm_obfuscator_pluto" ]; then
 # Clone and build Pluto
     echo "Cloning and building Pluto-obfuscator..."
     git clone https://github.com/thomasxm/Pluto.git
     cd Pluto && mkdir -p pluto_build
     cd pluto_build
-    
-    # cmake -G Ninja -S .. -B build \
-    #     -DCMAKE_C_COMPILER="gcc" -DCMAKE_CXX_COMPILER="g++" \
-    #     -DCMAKE_CXX_STANDARD=14 \  # Force C++14
-    #     -DCMAKE_INSTALL_PREFIX="../llvm_obfuscator_pluto/" \
-    #     -DCMAKE_BUILD_TYPE=Release \
-    #     -DLLVM_TARGETS_TO_BUILD="X86;AArch64;ARM;Mips" \
-    #     -DLLVM_ENABLE_PROJECTS="clang"
-
     cmake -G Ninja -S .. -B build -DCMAKE_C_COMPILER="gcc" -DCMAKE_CXX_COMPILER="g++" -DCMAKE_INSTALL_PREFIX="../llvm_obfuscator_pluto/" -DCMAKE_BUILD_TYPE=Release
     ninja -j2 -C build install
     mkdir -p ../../../llvm_obfuscator_pluto/
-    mv ../llvm_obfuscator_pluto ../../
-    cd ../../
-
-    if [ -f "./llvm_obfuscator_pluto/bin/clang++" ]; then
-        echo "Pluto installed successfully."
-        # rm -r Pluto
-    else
-        echo "Error: Pluto installation failed."
-        # exit 1
-    fi
-
+    mv ./install/* ../../../llvm_obfuscator_pluto/
+    cd ../../../ 
+    rm -r Pluto
 else 
     echo -e "${GREEN}[!] Pluto is already installed.${NC}"
-fi
 
+fi
 echo "start unit test:"
-./llvm_obfuscator_pluto/bin/clang++ -D nullptr=NULL -O2 -flto -fuse-ld=lld -mllvm -passes=mba,sub,idc,bcf,fla,gle -Xlinker -mllvm -Xlinker -passes=hlw,idc -target x86_64-w64-mingw32 loader2_test.c ./classic_stubs/syscalls.c ./classic_stubs/syscallsstubs.std.x64.s -o ./notepad_llvm.exe -v -L$MINGW_DIR -L./clang_test_include -I./c++/ -I./c++/mingw32/ -lws2_32 -lpsapi
+./Pluto/llvm_obfuscator_pluto/bin/clang++ -D nullptr=NULL -O2 -flto -fuse-ld=lld -mllvm -passes=mba,sub,idc,bcf,fla,gle -Xlinker -mllvm -Xlinker -passes=hlw,idc -target x86_64-w64-mingw32 loader2_test.c ./classic_stubs/syscalls.c ./classic_stubs/syscallsstubs.std.x64.s -o ./notepad_llvm.exe -v -L$MINGW_DIR -L./clang_test_include -I./c++/ -I./c++/mingw32/ -lws2_32 -lpsapi
 wine ./notepad_llvm.exe
 if [ -f "./notepad_llvm.exe" ]; then
     wine ./notepad_llvm.exe


### PR DESCRIPTION
the requirements.sh file misses installing nasm. 

Additionally, upon initial builds, the "llvm_obfuscator_pluto" directory remains nested under the "Pluto" directory, leading to issues when using pluto for the first time. 

These fixes add nasm and update the directory from "./llvm_obfuscator_pluto/bin/clang++" to "./Pluto/llvm_obfuscator_pluto/bin/clang++" in multiple places. 