### PR TITLE
Fix typos in loader comments

### DIFF
--- a/loaders/loader_template_73.c
+++ b/loaders/loader_template_73.c
@@ -2472,7 +2472,7 @@ int main(int argc, char *argv[])
 
 
 
-        // This part has been written into the pretext code, so that the memory guard is on until the last miunte of execution. 
+        // This part has been written into the pretext code, so that the memory guard is on until the last minute of execution.
         if(bUseNoAccess) {
             // //change the memory protection back to PAGE_EXECUTE_READ:
                 status = NtProtectVirtualMemory(

--- a/loaders/loader_template_74.c
+++ b/loaders/loader_template_74.c
@@ -2547,7 +2547,7 @@ int main(int argc, char *argv[])
 
 
 
-        // This part has been written into the pretext code, so that the memory guard is on until the last miunte of execution. 
+        // This part has been written into the pretext code, so that the memory guard is on until the last minute of execution.
         if(bUseNoAccess) {
             // // //change the memory protection back to PAGE_EXECUTE_READ:
             //     status = NtProtectVirtualMemory(


### PR DESCRIPTION
## Summary
- correct "miunte" typo to "minute" in loader templates

## Testing
- `grep -R "miunte" -n`

------
https://chatgpt.com/codex/tasks/task_e_68851119aa648327b28dcbc3978450ab